### PR TITLE
Fixing block placement when loading the cannon

### DIFF
--- a/src/at/pavlov/Cannons/listener/PlayerListener.java
+++ b/src/at/pavlov/Cannons/listener/PlayerListener.java
@@ -531,6 +531,7 @@ public class PlayerListener implements Listener
 						player.sendMessage(userMessages.getloadProjectile(ItemInHand.getId()));
 
 						InvManage.TakeFromPlayerInventory(player, config.inventory_take);
+						event.setCancelled(true);
 						return;
 					}
 				}
@@ -544,6 +545,7 @@ public class PlayerListener implements Listener
 						player.sendMessage(userMessages.getloadGunpowder(cannon_loc.gunpowder));
 						// take item from the player
 						InvManage.TakeFromPlayerInventory(player, config.inventory_take);
+						event.setCancelled(true);
 						return;
 					}
 				}


### PR DESCRIPTION
When loading the cannon, the ammo remains stuck to the barrel. This commit fixes that, by cancelling the PlayerInteractEvent.
