### PR TITLE
Fix gunpowder duplication exploit 

### DIFF
--- a/src/main/java/at/pavlov/cannons/cannon/Cannon.java
+++ b/src/main/java/at/pavlov/cannons/cannon/Cannon.java
@@ -783,7 +783,7 @@ public class Cannon
     private void dropCharge()
     {
         //drop gunpowder
-        if (loadedGunpowder > 0 && !design.isGunpowderNeeded())
+        if (loadedGunpowder > 0 && design.isGunpowderNeeded())
         {
             ItemStack powder = design.getGunpowderType().toItemStack(loadedGunpowder);
             getWorldBukkit().dropItemNaturally(design.getMuzzle(this), powder);


### PR DESCRIPTION
Cannons which do not require gunpowder (i.e. `needsGunpowder: false`) actually have the maximum amount of gunpowder they can possess (i.e. `maxLoadableGunpowder`) automatically loaded into them by the plugin when built (so the player does not have to load gunpowder themselves). However, this gunpowder is dropped when the cannon is broken. This means any player who repeatedly builds and breaks a cannon with `needsGunpowder` set to false can obtain an endless supply of gunpowder. This simple PR fixes the exploit by ensuring a cannon requires gunpowder before dropping it. 