### PR TITLE
Fix explosion particle effect when firing

### DIFF
--- a/src/main/java/at/pavlov/cannons/FireCannon.java
+++ b/src/main/java/at/pavlov/cannons/FireCannon.java
@@ -381,7 +381,7 @@ public class FireCannon {
 
         //simple particle effects for close distance
         //loc.getWorld().createExplosion(loc, 0F, false);
-        loc.getWorld().spawnParticle(Particle.EXPLOSION_LARGE, loc, 0);
+        loc.getWorld().spawnParticle(Particle.EXPLOSION_LARGE, loc, 1);
         //fake blocks effects for far distance
         if (config.isImitatedFiringEffectEnabled()) {
             int maxSoundDist = config.getImitatedSoundMaximumDistance();


### PR DESCRIPTION
The "count" argument of the method was set to 0 so no particles were spawned.