### PR TITLE
Allow the use of particles for smoke trails

### DIFF
--- a/src/main/java/at/pavlov/cannons/projectile/Projectile.java
+++ b/src/main/java/at/pavlov/cannons/projectile/Projectile.java
@@ -7,6 +7,7 @@ import at.pavlov.cannons.container.SoundHolder;
 import at.pavlov.cannons.container.SpawnEntityHolder;
 import at.pavlov.cannons.container.SpawnMaterialHolder;
 import org.bukkit.FireworkEffect;
+import org.bukkit.Particle;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -19,102 +20,109 @@ import at.pavlov.cannons.container.ItemHolder;
 public class Projectile implements Cloneable{
 	private String projectileID;
 	private String projectileName;
-    private String description;
+	private String description;
 	private String itemName;
 	private ItemHolder loadingItem;
 	//list of items or blocks that can represent this this (e.g. redstone dust may for wire when you click a block)
 	private List<ItemHolder> alternativeItemList = new ArrayList<ItemHolder>();
-	
+
 	//properties of the cannonball
-    private EntityType projectileEntity;
-    private boolean projectileOnFire;
-	private double velocity;	
+	private EntityType projectileEntity;
+	private boolean projectileOnFire;
+	private double velocity;
 	private double penetration;
 	private double timefuse;
-    private double automaticFiringDelay;
-    private int automaticFiringMagazineSize;
+	private double automaticFiringDelay;
+	private int automaticFiringMagazineSize;
 	private int numberOfBullets;
 	private double spreadMultiplier;
 	private List<ProjectileProperties> propertyList = new ArrayList<ProjectileProperties>();
 
-    //smokeTrail
-    private boolean smokeTrailEnabled;
-    private int smokeTrailDistance;
-    private BlockData smokeTrailMaterial;
-    private double smokeTrailDuration;
-	
+	//smokeTrail
+	private boolean smokeTrailEnabled;
+	private int smokeTrailDistance;
+	private BlockData smokeTrailMaterial;
+	private double smokeTrailDuration;
+	private boolean smokeTrailParticleEnabled;
+	private Particle smokeTrailParticleType;
+	private int smokeTrailParticleCount;
+	private double smokeTrailParticleOffsetX;
+	private double smokeTrailParticleOffsetY;
+	private double smokeTrailParticleOffsetZ;
+	private double smokeTrailParticleSpeed;
+
 	//explosion
 	private float explosionPower;
 	private boolean explosionPowerDependsOnVelocity;
 	private boolean explosionDamage;
-    private boolean underwaterDamage;
+	private boolean underwaterDamage;
 	private boolean penetrationDamage;
-    private double directHitDamage;
-    private double playerDamageRange;
-    private double playerDamage;
+	private double directHitDamage;
+	private double playerDamageRange;
+	private double playerDamage;
 	private double potionRange;
 	private double potionDuration;
 	private int potionAmplifier;
 	private List<PotionEffectType> potionsEffectList = new ArrayList<PotionEffectType>();
 	private boolean impactIndicator;
 
-    //cluster
-    private boolean clusterExplosionsEnabled;
-    private boolean clusterExplosionsInBlocks;
-    private int clusterExplosionsAmount;
-    private double clusterExplosionsMinDelay;
-    private double clusterExplosionsMaxDelay;
-    private double clusterExplosionsRadius;
-    private double clusterExplosionsPower;
+	//cluster
+	private boolean clusterExplosionsEnabled;
+	private boolean clusterExplosionsInBlocks;
+	private int clusterExplosionsAmount;
+	private double clusterExplosionsMinDelay;
+	private double clusterExplosionsMaxDelay;
+	private double clusterExplosionsRadius;
+	private double clusterExplosionsPower;
 
-    //placeBlock
-    private boolean spawnEnabled;
+	//placeBlock
+	private boolean spawnEnabled;
 	private double spawnBlockRadius;
-    private double spawnEntityRadius;
-    private double spawnVelocity;
+	private double spawnEntityRadius;
+	private double spawnVelocity;
 	private List<SpawnMaterialHolder> spawnBlocks = new ArrayList<SpawnMaterialHolder>();
-    private List<SpawnEntityHolder> spawnEntities = new ArrayList<SpawnEntityHolder>();
-    private List<String> spawnProjectiles;
+	private List<SpawnEntityHolder> spawnEntities = new ArrayList<SpawnEntityHolder>();
+	private List<String> spawnProjectiles;
 
-    //spawn Fireworks
-    private boolean fireworksEnabled;
-    private boolean fireworksFlicker;
-    private boolean fireworksTrail;
-    private FireworkEffect.Type fireworksType;
-    private List<Integer> fireworksColors;
-    private List<Integer> fireworksFadeColors;
+	//spawn Fireworks
+	private boolean fireworksEnabled;
+	private boolean fireworksFlicker;
+	private boolean fireworksTrail;
+	private FireworkEffect.Type fireworksType;
+	private List<Integer> fireworksColors;
+	private List<Integer> fireworksFadeColors;
 
-    //messages
-    private boolean impactMessage;
+	//messages
+	private boolean impactMessage;
 
-    //sounds
-    private SoundHolder soundLoading;
-    private SoundHolder soundImpact;
-    private SoundHolder soundImpactProtected;
-    private SoundHolder soundImpactWater;
+	//sounds
+	private SoundHolder soundLoading;
+	private SoundHolder soundImpact;
+	private SoundHolder soundImpactProtected;
+	private SoundHolder soundImpactWater;
 
 	//permissions
 	private List<String> permissionLoad = new ArrayList<String>();
-	
+
 	public Projectile(String id)
 	{
 		this.projectileID = id;
 	}
 
-    @Override
-    public Projectile clone(){
-        try
-        {
-            // call clone in Object.
-            return (Projectile) super.clone();
-        }
-        catch(CloneNotSupportedException e)
-        {
-            System.out.println("Cloning not allowed.");
-            return this;
-        }
-    }
-	
+	@Override
+	public Projectile clone(){
+		try
+		{
+			// call clone in Object.
+			return (Projectile) super.clone();
+		}
+		catch(CloneNotSupportedException e)
+		{
+			System.out.println("Cloning not allowed.");
+			return this;
+		}
+	}
+
 	/**
 	 * returns true if both the id and data are equivalent of data == -1
 	 * @param materialHolder the material of the loaded item
@@ -122,8 +130,8 @@ public class Projectile implements Cloneable{
 	 */
 	public boolean equals(ItemHolder materialHolder)
 	{
-        return loadingItem.equalsFuzzy(materialHolder);
-    }
+		return loadingItem.equalsFuzzy(materialHolder);
+	}
 
 	/**
 	 * returns true if both the id and data are equivalent of data == -1
@@ -168,7 +176,7 @@ public class Projectile implements Cloneable{
 		}
 		return false;
 	}
-	
+
 	/**
 	 * returns true if the player has permission to use that projectile
 	 * @param player who tried to load this projectile
@@ -177,7 +185,7 @@ public class Projectile implements Cloneable{
 	public boolean hasPermission(Player player)
 	{
 		if (player == null) return true;
-		
+
 		for (String perm : permissionLoad)
 		{
 			if(!player.hasPermission(perm))
@@ -190,7 +198,7 @@ public class Projectile implements Cloneable{
 		return true;
 	}
 
-	
+
 
 	public String getItemName()
 	{
@@ -214,7 +222,7 @@ public class Projectile implements Cloneable{
 	{
 		this.projectileName = projectileName;
 	}
-	
+
 
 	public double getVelocity()
 	{
@@ -407,288 +415,288 @@ public class Projectile implements Cloneable{
 		this.permissionLoad = permissionLoad;
 	}
 
-    public double getDirectHitDamage() {
-        return directHitDamage;
-    }
+	public double getDirectHitDamage() {
+		return directHitDamage;
+	}
 
-    public void setDirectHitDamage(double directHitDamage) {
-        this.directHitDamage = directHitDamage;
-    }
+	public void setDirectHitDamage(double directHitDamage) {
+		this.directHitDamage = directHitDamage;
+	}
 
-    public double getPlayerDamageRange() {
-        return playerDamageRange;
-    }
+	public double getPlayerDamageRange() {
+		return playerDamageRange;
+	}
 
-    public void setPlayerDamageRange(double playerDamageRange) {
-        this.playerDamageRange = playerDamageRange;
-    }
+	public void setPlayerDamageRange(double playerDamageRange) {
+		this.playerDamageRange = playerDamageRange;
+	}
 
-    public double getPlayerDamage() {
-        return playerDamage;
-    }
+	public double getPlayerDamage() {
+		return playerDamage;
+	}
 
-    public void setPlayerDamage(double playerDamage) {
-        this.playerDamage = playerDamage;
-    }
+	public void setPlayerDamage(double playerDamage) {
+		this.playerDamage = playerDamage;
+	}
 
-    public boolean isImpactMessage() {
-        return impactMessage;
-    }
+	public boolean isImpactMessage() {
+		return impactMessage;
+	}
 
-    public void setImpactMessage(boolean impactMessage) {
-        this.impactMessage = impactMessage;
-    }
+	public void setImpactMessage(boolean impactMessage) {
+		this.impactMessage = impactMessage;
+	}
 
-    public boolean isUnderwaterDamage() {
-        return underwaterDamage;
-    }
+	public boolean isUnderwaterDamage() {
+		return underwaterDamage;
+	}
 
-    public void setUnderwaterDamage(boolean underwaterDamage) {
-        this.underwaterDamage = underwaterDamage;
-    }
+	public void setUnderwaterDamage(boolean underwaterDamage) {
+		this.underwaterDamage = underwaterDamage;
+	}
 
-    public boolean isFireworksFlicker() {
-        return fireworksFlicker;
-    }
+	public boolean isFireworksFlicker() {
+		return fireworksFlicker;
+	}
 
-    public void setFireworksFlicker(boolean fireworksFlicker) {
-        this.fireworksFlicker = fireworksFlicker;
-    }
+	public void setFireworksFlicker(boolean fireworksFlicker) {
+		this.fireworksFlicker = fireworksFlicker;
+	}
 
-    public FireworkEffect.Type getFireworksType() {
-        return fireworksType;
-    }
+	public FireworkEffect.Type getFireworksType() {
+		return fireworksType;
+	}
 
-    public void setFireworksType(FireworkEffect.Type fireworksType) {
-        this.fireworksType = fireworksType;
-    }
+	public void setFireworksType(FireworkEffect.Type fireworksType) {
+		this.fireworksType = fireworksType;
+	}
 
-    public List<Integer> getFireworksColors() {
-        return fireworksColors;
-    }
+	public List<Integer> getFireworksColors() {
+		return fireworksColors;
+	}
 
-    public void setFireworksColors(List<Integer> fireworksColors) {
-        this.fireworksColors = fireworksColors;
-    }
+	public void setFireworksColors(List<Integer> fireworksColors) {
+		this.fireworksColors = fireworksColors;
+	}
 
-    public List<Integer> getFireworksFadeColors() {
-        return fireworksFadeColors;
-    }
+	public List<Integer> getFireworksFadeColors() {
+		return fireworksFadeColors;
+	}
 
-    public void setFireworksFadeColors(List<Integer> fireworksFadeColors) {
-        this.fireworksFadeColors = fireworksFadeColors;
-    }
+	public void setFireworksFadeColors(List<Integer> fireworksFadeColors) {
+		this.fireworksFadeColors = fireworksFadeColors;
+	}
 
-    public boolean isFireworksTrail() {
-        return fireworksTrail;
-    }
+	public boolean isFireworksTrail() {
+		return fireworksTrail;
+	}
 
-    public void setFireworksTrail(boolean fireworksTrail) {
-        this.fireworksTrail = fireworksTrail;
-    }
+	public void setFireworksTrail(boolean fireworksTrail) {
+		this.fireworksTrail = fireworksTrail;
+	}
 
-    public double getAutomaticFiringDelay() {
-        return automaticFiringDelay;
-    }
+	public double getAutomaticFiringDelay() {
+		return automaticFiringDelay;
+	}
 
-    public void setAutomaticFiringDelay(double automaticFiringDelay) {
-        this.automaticFiringDelay = automaticFiringDelay;
-    }
+	public void setAutomaticFiringDelay(double automaticFiringDelay) {
+		this.automaticFiringDelay = automaticFiringDelay;
+	}
 
-    public int getAutomaticFiringMagazineSize() {
-        return automaticFiringMagazineSize;
-    }
+	public int getAutomaticFiringMagazineSize() {
+		return automaticFiringMagazineSize;
+	}
 
-    public void setAutomaticFiringMagazineSize(int automaticFiringMagazineSize) {
-        this.automaticFiringMagazineSize = automaticFiringMagazineSize;
-    }
+	public void setAutomaticFiringMagazineSize(int automaticFiringMagazineSize) {
+		this.automaticFiringMagazineSize = automaticFiringMagazineSize;
+	}
 
-    public boolean isFireworksEnabled() {
-        return fireworksEnabled;
-    }
+	public boolean isFireworksEnabled() {
+		return fireworksEnabled;
+	}
 
-    public void setFireworksEnabled(boolean fireworksEnabled) {
-        this.fireworksEnabled = fireworksEnabled;
-    }
+	public void setFireworksEnabled(boolean fireworksEnabled) {
+		this.fireworksEnabled = fireworksEnabled;
+	}
 
-    public EntityType getProjectileEntity() {
-        return projectileEntity;
-    }
+	public EntityType getProjectileEntity() {
+		return projectileEntity;
+	}
 
-    public void setProjectileEntity(EntityType projectileEntity) {
-        this.projectileEntity = projectileEntity;
-    }
+	public void setProjectileEntity(EntityType projectileEntity) {
+		this.projectileEntity = projectileEntity;
+	}
 
-    public boolean isProjectileOnFire() {
-        return projectileOnFire;
-    }
+	public boolean isProjectileOnFire() {
+		return projectileOnFire;
+	}
 
-    public void setProjectileOnFire(boolean projectileOnFire) {
-        this.projectileOnFire = projectileOnFire;
-    }
+	public void setProjectileOnFire(boolean projectileOnFire) {
+		this.projectileOnFire = projectileOnFire;
+	}
 
-    public String getDescription() {
-        return description;
-    }
+	public String getDescription() {
+		return description;
+	}
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
+	public void setDescription(String description) {
+		this.description = description;
+	}
 
 	public boolean isExplosionPowerDependsOnVelocity()
 	{
 		return explosionPowerDependsOnVelocity;
 	}
-	
+
 
 	public void setExplosionPowerDependsOnVelocity(boolean explosionPowerDependsOnVelocity)
 	{
 		this.explosionPowerDependsOnVelocity = explosionPowerDependsOnVelocity;
 	}
 
-    public boolean isClusterExplosionsEnabled() {
-        return clusterExplosionsEnabled;
-    }
+	public boolean isClusterExplosionsEnabled() {
+		return clusterExplosionsEnabled;
+	}
 
-    public void setClusterExplosionsEnabled(boolean clusterExplosionsEnabled) {
-        this.clusterExplosionsEnabled = clusterExplosionsEnabled;
-    }
+	public void setClusterExplosionsEnabled(boolean clusterExplosionsEnabled) {
+		this.clusterExplosionsEnabled = clusterExplosionsEnabled;
+	}
 
-    public int getClusterExplosionsAmount() {
-        return clusterExplosionsAmount;
-    }
+	public int getClusterExplosionsAmount() {
+		return clusterExplosionsAmount;
+	}
 
-    public void setClusterExplosionsAmount(int clusterExplosionsAmount) {
-        this.clusterExplosionsAmount = clusterExplosionsAmount;
-    }
+	public void setClusterExplosionsAmount(int clusterExplosionsAmount) {
+		this.clusterExplosionsAmount = clusterExplosionsAmount;
+	}
 
-    public double getClusterExplosionsRadius() {
-        return clusterExplosionsRadius;
-    }
+	public double getClusterExplosionsRadius() {
+		return clusterExplosionsRadius;
+	}
 
-    public void setClusterExplosionsRadius(double clusterExplosionsRadius) {
-        this.clusterExplosionsRadius = clusterExplosionsRadius;
-    }
+	public void setClusterExplosionsRadius(double clusterExplosionsRadius) {
+		this.clusterExplosionsRadius = clusterExplosionsRadius;
+	}
 
-    public boolean isClusterExplosionsInBlocks() {
-        return clusterExplosionsInBlocks;
-    }
+	public boolean isClusterExplosionsInBlocks() {
+		return clusterExplosionsInBlocks;
+	}
 
-    public void setClusterExplosionsInBlocks(boolean clusterExplosionsInBlocks) {
-        this.clusterExplosionsInBlocks = clusterExplosionsInBlocks;
-    }
+	public void setClusterExplosionsInBlocks(boolean clusterExplosionsInBlocks) {
+		this.clusterExplosionsInBlocks = clusterExplosionsInBlocks;
+	}
 
-    public double getClusterExplosionsMinDelay() {
-        return clusterExplosionsMinDelay;
-    }
+	public double getClusterExplosionsMinDelay() {
+		return clusterExplosionsMinDelay;
+	}
 
-    public void setClusterExplosionsMinDelay(double clusterExplosionsMinDelay) {
-        this.clusterExplosionsMinDelay = clusterExplosionsMinDelay;
-    }
+	public void setClusterExplosionsMinDelay(double clusterExplosionsMinDelay) {
+		this.clusterExplosionsMinDelay = clusterExplosionsMinDelay;
+	}
 
-    public double getClusterExplosionsMaxDelay() {
-        return clusterExplosionsMaxDelay;
-    }
+	public double getClusterExplosionsMaxDelay() {
+		return clusterExplosionsMaxDelay;
+	}
 
-    public void setClusterExplosionsMaxDelay(double clusterExplosionsMaxDelay) {
-        this.clusterExplosionsMaxDelay = clusterExplosionsMaxDelay;
-    }
+	public void setClusterExplosionsMaxDelay(double clusterExplosionsMaxDelay) {
+		this.clusterExplosionsMaxDelay = clusterExplosionsMaxDelay;
+	}
 
-    public double getClusterExplosionsPower() {
-        return clusterExplosionsPower;
-    }
+	public double getClusterExplosionsPower() {
+		return clusterExplosionsPower;
+	}
 
-    public void setClusterExplosionsPower(double clusterExplosionsPower) {
-        this.clusterExplosionsPower = clusterExplosionsPower;
-    }
+	public void setClusterExplosionsPower(double clusterExplosionsPower) {
+		this.clusterExplosionsPower = clusterExplosionsPower;
+	}
 
-    public boolean isSpawnEnabled() {
-        return spawnEnabled;
-    }
+	public boolean isSpawnEnabled() {
+		return spawnEnabled;
+	}
 
-    public void setSpawnEnabled(boolean spawnEnabled) {
-        this.spawnEnabled = spawnEnabled;
-    }
+	public void setSpawnEnabled(boolean spawnEnabled) {
+		this.spawnEnabled = spawnEnabled;
+	}
 
-    public double getSpawnVelocity() {
-        return spawnVelocity;
-    }
+	public double getSpawnVelocity() {
+		return spawnVelocity;
+	}
 
-    public void setSpawnVelocity(double spawnVelocity) {
-        this.spawnVelocity = spawnVelocity;
-    }
+	public void setSpawnVelocity(double spawnVelocity) {
+		this.spawnVelocity = spawnVelocity;
+	}
 
-    public List<SpawnMaterialHolder> getSpawnBlocks() {
-        return spawnBlocks;
-    }
+	public List<SpawnMaterialHolder> getSpawnBlocks() {
+		return spawnBlocks;
+	}
 
-    public void setSpawnBlocks(List<SpawnMaterialHolder> spawnBlocks) {
-        this.spawnBlocks = spawnBlocks;
-    }
+	public void setSpawnBlocks(List<SpawnMaterialHolder> spawnBlocks) {
+		this.spawnBlocks = spawnBlocks;
+	}
 
-    public List<SpawnEntityHolder> getSpawnEntities() {
-        return spawnEntities;
-    }
+	public List<SpawnEntityHolder> getSpawnEntities() {
+		return spawnEntities;
+	}
 
-    public void setSpawnEntities(List<SpawnEntityHolder> spawnEntities) {
-        this.spawnEntities = spawnEntities;
-    }
+	public void setSpawnEntities(List<SpawnEntityHolder> spawnEntities) {
+		this.spawnEntities = spawnEntities;
+	}
 
-    public List<String> getSpawnProjectiles() {
-        return spawnProjectiles;
-    }
+	public List<String> getSpawnProjectiles() {
+		return spawnProjectiles;
+	}
 
-    public void setSpawnProjectiles(List<String> spawnProjectiles) {
-        this.spawnProjectiles = spawnProjectiles;
-    }
+	public void setSpawnProjectiles(List<String> spawnProjectiles) {
+		this.spawnProjectiles = spawnProjectiles;
+	}
 
-    public double getSpawnEntityRadius() {
-        return spawnEntityRadius;
-    }
+	public double getSpawnEntityRadius() {
+		return spawnEntityRadius;
+	}
 
-    public void setSpawnEntityRadius(double spawnEntityRadius) {
-        this.spawnEntityRadius = spawnEntityRadius;
-    }
+	public void setSpawnEntityRadius(double spawnEntityRadius) {
+		this.spawnEntityRadius = spawnEntityRadius;
+	}
 
-    public double getSpawnBlockRadius() {
-        return spawnBlockRadius;
-    }
+	public double getSpawnBlockRadius() {
+		return spawnBlockRadius;
+	}
 
-    public void setSpawnBlockRadius(double spawnBlockRadius) {
-        this.spawnBlockRadius = spawnBlockRadius;
-    }
+	public void setSpawnBlockRadius(double spawnBlockRadius) {
+		this.spawnBlockRadius = spawnBlockRadius;
+	}
 
-    public SoundHolder getSoundLoading() {
-        return soundLoading;
-    }
+	public SoundHolder getSoundLoading() {
+		return soundLoading;
+	}
 
-    public void setSoundLoading(SoundHolder soundLoading) {
-        this.soundLoading = soundLoading;
-    }
+	public void setSoundLoading(SoundHolder soundLoading) {
+		this.soundLoading = soundLoading;
+	}
 
-    public SoundHolder getSoundImpact() {
-        return soundImpact;
-    }
+	public SoundHolder getSoundImpact() {
+		return soundImpact;
+	}
 
-    public void setSoundImpact(SoundHolder soundImpact) {
-        this.soundImpact = soundImpact;
-    }
+	public void setSoundImpact(SoundHolder soundImpact) {
+		this.soundImpact = soundImpact;
+	}
 
-    public SoundHolder getSoundImpactWater() {
-        return soundImpactWater;
-    }
+	public SoundHolder getSoundImpactWater() {
+		return soundImpactWater;
+	}
 
-    public void setSoundImpactWater(SoundHolder soundImpactWater) {
-        this.soundImpactWater = soundImpactWater;
-    }
+	public void setSoundImpactWater(SoundHolder soundImpactWater) {
+		this.soundImpactWater = soundImpactWater;
+	}
 
-    public SoundHolder getSoundImpactProtected() {
-        return soundImpactProtected;
-    }
+	public SoundHolder getSoundImpactProtected() {
+		return soundImpactProtected;
+	}
 
-    public void setSoundImpactProtected(SoundHolder soundImpactProtected) {
-        this.soundImpactProtected = soundImpactProtected;
-    }
+	public void setSoundImpactProtected(SoundHolder soundImpactProtected) {
+		this.soundImpactProtected = soundImpactProtected;
+	}
 
 	public boolean isImpactIndicator() {
 		return impactIndicator;
@@ -698,35 +706,78 @@ public class Projectile implements Cloneable{
 		this.impactIndicator = impactIndicator;
 	}
 
-    public boolean isSmokeTrailEnabled() {
-        return smokeTrailEnabled;
-    }
+	public boolean isSmokeTrailEnabled() {
+		return smokeTrailEnabled;
+	}
 
-    public void setSmokeTrailEnabled(boolean smokeTrailEnabled) {
-        this.smokeTrailEnabled = smokeTrailEnabled;
-    }
+	public void setSmokeTrailEnabled(boolean smokeTrailEnabled) {
+		this.smokeTrailEnabled = smokeTrailEnabled;
+	}
 
-    public BlockData getSmokeTrailMaterial() {
-        return smokeTrailMaterial;
-    }
+	public BlockData getSmokeTrailMaterial() {
+		return smokeTrailMaterial;
+	}
 
-    public void setSmokeTrailMaterial(BlockData smokeTrailMaterial) {
-        this.smokeTrailMaterial = smokeTrailMaterial;
-    }
+	public void setSmokeTrailMaterial(BlockData smokeTrailMaterial) {
+		this.smokeTrailMaterial = smokeTrailMaterial;
+	}
 
-    public double getSmokeTrailDuration() {
-        return smokeTrailDuration;
-    }
+	public double getSmokeTrailDuration() {
+		return smokeTrailDuration;
+	}
 
-    public void setSmokeTrailDuration(double smokeTrailDuration) {
-        this.smokeTrailDuration = smokeTrailDuration;
-    }
+	public void setSmokeTrailDuration(double smokeTrailDuration) {
+		this.smokeTrailDuration = smokeTrailDuration;
+	}
 
-    public int getSmokeTrailDistance() {
-        return smokeTrailDistance;
-    }
+	public int getSmokeTrailDistance() {
+		return smokeTrailDistance;
+	}
 
-    public void setSmokeTrailDistance(int smokeTrailDistance) {
-        this.smokeTrailDistance = smokeTrailDistance;
-    }
+	public void setSmokeTrailDistance(int smokeTrailDistance) {
+		this.smokeTrailDistance = smokeTrailDistance;
+	}
+
+	public void setSmokeTrailParticleEnabled(boolean smokeTrailParticleEnabled) {
+		this.smokeTrailParticleEnabled = smokeTrailParticleEnabled;
+	}
+
+	public boolean isSmokeTrailParticleEnabled() { return smokeTrailParticleEnabled; }
+
+	public void setSmokeTrailParticleType(Particle smokeTrailParticleType) {
+		this.smokeTrailParticleType = smokeTrailParticleType;
+	}
+
+	public Particle getSmokeTrailParticleType() { return smokeTrailParticleType; }
+
+	public void setSmokeTrailParticleCount(int smokeTrailParticleCount) {
+		this.smokeTrailParticleCount = smokeTrailParticleCount;
+	}
+
+	public int getSmokeTrailParticleCount() { return smokeTrailParticleCount; }
+
+	public void setSmokeTrailParticleOffsetX(double smokeTrailParticleOffsetX) {
+		this.smokeTrailParticleOffsetX = smokeTrailParticleOffsetX;
+	}
+
+	public double getSmokeTrailParticleOffsetX() { return smokeTrailParticleOffsetX; }
+
+	public void setSmokeTrailParticleOffsetY(double smokeTrailParticleOffsetY) {
+		this.smokeTrailParticleOffsetY = smokeTrailParticleOffsetY;
+	}
+
+	public double getSmokeTrailParticleOffsetY() { return smokeTrailParticleOffsetY; }
+
+	public void setSmokeTrailParticleOffsetZ(double smokeTrailParticleOffsetZ) {
+		this.smokeTrailParticleOffsetZ = smokeTrailParticleOffsetZ;
+	}
+
+	public double getSmokeTrailParticleOffsetZ() { return smokeTrailParticleOffsetZ; }
+
+	public void setSmokeTrailParticleSpeed(double smokeTrailParticleSpeed) {
+		this.smokeTrailParticleSpeed = smokeTrailParticleSpeed;
+	}
+
+	public double getSmokeTrailParticleSpeed() { return smokeTrailParticleSpeed; }
+
 }

--- a/src/main/java/at/pavlov/cannons/projectile/ProjectileStorage.java
+++ b/src/main/java/at/pavlov/cannons/projectile/ProjectileStorage.java
@@ -8,6 +8,7 @@ import at.pavlov.cannons.container.SoundHolder;
 import org.bukkit.Bukkit;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.EntityType;
@@ -24,8 +25,8 @@ public class ProjectileStorage
 	private final Cannons plugin;
 
 
-    private static List<Projectile> projectileList;
-	
+	private static List<Projectile> projectileList;
+
 	public ProjectileStorage(Cannons plugin)
 	{
 		this.plugin = plugin;
@@ -35,7 +36,7 @@ public class ProjectileStorage
 	/**
 	 * returns a list of all projectiles names
 	 * @return list of all projectiles names
-     */
+	 */
 	public static ArrayList<String> getProjectileIds(){
 		ArrayList<String> list = new ArrayList<String>();
 		for (Projectile proj : projectileList){
@@ -51,10 +52,10 @@ public class ProjectileStorage
 	 */
 	public static Projectile getProjectile(Cannon cannon, ItemStack item)
 	{
-        ItemHolder materialHolder = new ItemHolder(item);
-        return getProjectile(cannon, materialHolder);
+		ItemHolder materialHolder = new ItemHolder(item);
+		return getProjectile(cannon, materialHolder);
 	}
-	
+
 	/**
 	 * returns the projectiles that can be loaded in the cannon with this id and data. If data=-1 the data is ignored
 	 * @param materialHolder material of the projectile
@@ -64,27 +65,27 @@ public class ProjectileStorage
 	{
 		for (Projectile projectile : projectileList)
 		{
-            if (cannon.getCannonDesign().canLoad(projectile) && !projectile.getLoadingItem().equals(Material.AIR) && projectile.equals(materialHolder))
+			if (cannon.getCannonDesign().canLoad(projectile) && !projectile.getLoadingItem().equals(Material.AIR) && projectile.equals(materialHolder))
 				return projectile;
 		}
 		return null;
 	}
 
 
-    /**
-     * returns the projectiles that can be loaded in the cannon by projectile id (file name)
-     * @param projectileId id of the projectile
-     * @return true if there is a projectile with this id
-     */
-    public static Projectile getProjectile(Cannon cannon, String projectileId)
-    {
-        for (Projectile projectile : projectileList)
-        {
-            if (cannon.getCannonDesign().canLoad(projectile) && projectile.equals(projectileId))
-                return projectile;
-        }
-        return null;
-    }
+	/**
+	 * returns the projectiles that can be loaded in the cannon by projectile id (file name)
+	 * @param projectileId id of the projectile
+	 * @return true if there is a projectile with this id
+	 */
+	public static Projectile getProjectile(Cannon cannon, String projectileId)
+	{
+		for (Projectile projectile : projectileList)
+		{
+			if (cannon.getCannonDesign().canLoad(projectile) && projectile.equals(projectileId))
+				return projectile;
+		}
+		return null;
+	}
 
 	/**
 	 * returns the projectiles for the given id (file name)
@@ -100,17 +101,17 @@ public class ProjectileStorage
 		}
 		return null;
 	}
-	
+
 	/**
 	 * loads all projectile designs from the disk or copys the defaults if there is no design
 	 */
 	public void loadProjectiles()
 	{
 		plugin.logInfo("Loading projectile configs");
-		
+
 		//clear old list
 		projectileList.clear();
-		
+
 		//load defaults if there no projectile folder
 		// check if design folder is empty or does not exist
 		if (CannonsUtil.isFolderEmpty(getPath()))
@@ -119,10 +120,10 @@ public class ProjectileStorage
 			plugin.logInfo("No projectiles loaded - loading default projectiles");
 			copyDefaultProjectiles();
 		}
-		
+
 		//get list of all files in /projectiles/
 		ArrayList<String> projectileFileList = getProjectilesFiles();
-		
+
 		// stop if there are no files found
 		if (projectileFileList == null || projectileFileList.size() == 0)
 			return;
@@ -135,9 +136,9 @@ public class ProjectileStorage
 				plugin.logDebug("load projectile " + file + " item " + projectile.getLoadingItem().toString());
 				projectileList.add(projectile);
 			}
-		}	
+		}
 	}
-	
+
 	/**
 	 * get all projectile file names form /projectiles
 	 * @return list of all projectiles files
@@ -153,11 +154,11 @@ public class ProjectileStorage
 			File folder = new File(getPath());
 
 			File[] listOfFiles = folder.listFiles();
-            if (listOfFiles == null)
-            {
-                plugin.logSevere("Projectile folder empty");
-                return projectileList;
-            }
+			if (listOfFiles == null)
+			{
+				plugin.logSevere("Projectile folder empty");
+				return projectileList;
+			}
 
 			for (File listOfFile : listOfFiles) {
 				if (listOfFile.isFile()) {
@@ -175,7 +176,7 @@ public class ProjectileStorage
 		}
 		return projectileList;
 	}
-	
+
 	/**
 	 * loads the config for one cannon from the .yml file
 	 * @param ymlFile
@@ -189,44 +190,51 @@ public class ProjectileStorage
 		// load .yml file
 
 		File projectileFile = new File(getPath() + ymlFile);
-        FileConfiguration projectileConfig = YamlConfiguration.loadConfiguration(projectileFile);
-		
+		FileConfiguration projectileConfig = YamlConfiguration.loadConfiguration(projectileFile);
+
 		//load it from the disk
-		
+
 		//general
 		projectile.setProjectileName(projectileConfig.getString("general.projectileName", "noProjectileName"));
-        projectile.setDescription(projectileConfig.getString("general.description", "no description for this projectile"));
+		projectile.setDescription(projectileConfig.getString("general.description", "no description for this projectile"));
 		projectile.setItemName(projectileConfig.getString("general.itemName", "noItemName"));
 		projectile.setLoadingItem(new ItemHolder(projectileConfig.getString("general.loadingItem", "minecraft:cobblestone")));
 		projectile.setAlternativeItemList(CannonsUtil.toItemHolderList(projectileConfig.getStringList("general.alternativeId")));
-		
+
 		//cannonball
-        projectile.setProjectileEntity(getProjectileEntity(projectileConfig.getString("cannonball.entityType", "SNOWBALL")));
-        projectile.setProjectileOnFire(projectileConfig.getBoolean("cannonball.isOnFire", false));
+		projectile.setProjectileEntity(getProjectileEntity(projectileConfig.getString("cannonball.entityType", "SNOWBALL")));
+		projectile.setProjectileOnFire(projectileConfig.getBoolean("cannonball.isOnFire", false));
 		projectile.setVelocity(projectileConfig.getDouble("cannonball.velocity", 1.0));
 		projectile.setPenetration(projectileConfig.getDouble("cannonball.penetration", 0.0));
 		projectile.setPenetrationDamage(projectileConfig.getBoolean("cannonball.doesPenetrationDamage", true));
 		projectile.setTimefuse(projectileConfig.getDouble("cannonball.timefuse", 0.0));
-        projectile.setAutomaticFiringDelay(projectileConfig.getDouble("cannonball.automaticFiringDelay", 1.0));
-        projectile.setAutomaticFiringMagazineSize(projectileConfig.getInt("cannonball.automaticFiringMagazineSize", 1));
+		projectile.setAutomaticFiringDelay(projectileConfig.getDouble("cannonball.automaticFiringDelay", 1.0));
+		projectile.setAutomaticFiringMagazineSize(projectileConfig.getInt("cannonball.automaticFiringMagazineSize", 1));
 		projectile.setNumberOfBullets(projectileConfig.getInt("cannonball.numberOfBullets", 1));
 		projectile.setSpreadMultiplier(projectileConfig.getDouble("cannonball.spreadMultiplier", 1.0));
 		projectile.setPropertyList(toProperties(projectileConfig.getStringList("cannonball.properties")));
 
-        //smokeTrail
-        projectile.setSmokeTrailEnabled(projectileConfig.getBoolean("smokeTrail.enabled", false));
-        projectile.setSmokeTrailDistance(projectileConfig.getInt("smokeTrail.distance", 10));
-        projectile.setSmokeTrailMaterial(Bukkit.createBlockData(projectileConfig.getString("smokeTrail.material", "minecraft:cobweb")));
-        projectile.setSmokeTrailDuration(projectileConfig.getDouble("smokeTrail.duration", 20.0));
-		
+		//smokeTrail
+		projectile.setSmokeTrailEnabled(projectileConfig.getBoolean("smokeTrail.enabled", false));
+		projectile.setSmokeTrailDistance(projectileConfig.getInt("smokeTrail.distance", 10));
+		projectile.setSmokeTrailMaterial(Bukkit.createBlockData(projectileConfig.getString("smokeTrail.material", "minecraft:cobweb")));
+		projectile.setSmokeTrailDuration(projectileConfig.getDouble("smokeTrail.duration", 20.0));
+		projectile.setSmokeTrailParticleEnabled(projectileConfig.getBoolean("smokeTrail.particles.enabled", false));
+		projectile.setSmokeTrailParticleType(Particle.valueOf(projectileConfig.getString("smokeTrail.particles.type", "CAMPFIRE_SIGNAL_SMOKE")));
+		projectile.setSmokeTrailParticleCount(projectileConfig.getInt("smokeTrail.particles.count", 1));
+		projectile.setSmokeTrailParticleOffsetX(projectileConfig.getDouble("smokeTrail.particles.x_offset", 0.0));
+		projectile.setSmokeTrailParticleOffsetY(projectileConfig.getDouble("smokeTrail.particles.y_offset", 0.0));
+		projectile.setSmokeTrailParticleOffsetZ(projectileConfig.getDouble("smokeTrail.particles.z_offset", 0.0));
+		projectile.setSmokeTrailParticleSpeed(projectileConfig.getDouble("smokeTrail.particles.speed", 0.0));
+
 		//explosion
 		projectile.setExplosionPower((float) projectileConfig.getDouble("explosion.explosionPower", 2.));
 		projectile.setExplosionPowerDependsOnVelocity(projectileConfig.getBoolean("explosion.explosionPowerDependsOnVelocity", true));
 		projectile.setExplosionDamage(projectileConfig.getBoolean("explosion.doesExplosionDamage", true));
-        projectile.setUnderwaterDamage(projectileConfig.getBoolean("explosion.doesUnderwaterExplosion", false));
-        projectile.setDirectHitDamage(projectileConfig.getDouble("explosion.directHitDamage", 5.0));
-        projectile.setPlayerDamageRange(projectileConfig.getDouble("explosion.playerDamageRange", 3.0));
-        projectile.setPlayerDamage(projectileConfig.getDouble("explosion.playerDamage", 5.0));
+		projectile.setUnderwaterDamage(projectileConfig.getBoolean("explosion.doesUnderwaterExplosion", false));
+		projectile.setDirectHitDamage(projectileConfig.getDouble("explosion.directHitDamage", 5.0));
+		projectile.setPlayerDamageRange(projectileConfig.getDouble("explosion.playerDamageRange", 3.0));
+		projectile.setPlayerDamage(projectileConfig.getDouble("explosion.playerDamage", 5.0));
 		projectile.setPotionRange(projectileConfig.getDouble("explosion.potionRange", 1.0));
 		projectile.setPotionDuration(projectileConfig.getDouble("explosion.potionDuration", 1.0));
 		projectile.setPotionAmplifier(projectileConfig.getInt("explosion.potionAmplifier", 0));
@@ -234,81 +242,81 @@ public class ProjectileStorage
 		projectile.setImpactIndicator(projectileConfig.getBoolean("explosion.impactIndicator", true));
 
 		//cluster
-        projectile.setClusterExplosionsEnabled(projectileConfig.getBoolean("clusterExplosion.enabled", false));
-        projectile.setClusterExplosionsInBlocks(projectileConfig.getBoolean("clusterExplosion.explosionInBlocks", false));
-        projectile.setClusterExplosionsAmount(projectileConfig.getInt("clusterExplosion.amount", 5));
-        projectile.setClusterExplosionsMinDelay(projectileConfig.getDouble("clusterExplosion.minDelay", 0.0));
-        projectile.setClusterExplosionsMaxDelay(projectileConfig.getDouble("clusterExplosion.maxDelay", 5.0));
-        projectile.setClusterExplosionsRadius(projectileConfig.getDouble("clusterExplosion.radius", 5.0));
-        projectile.setClusterExplosionsPower(projectileConfig.getDouble("clusterExplosion.power", 5.0));
+		projectile.setClusterExplosionsEnabled(projectileConfig.getBoolean("clusterExplosion.enabled", false));
+		projectile.setClusterExplosionsInBlocks(projectileConfig.getBoolean("clusterExplosion.explosionInBlocks", false));
+		projectile.setClusterExplosionsAmount(projectileConfig.getInt("clusterExplosion.amount", 5));
+		projectile.setClusterExplosionsMinDelay(projectileConfig.getDouble("clusterExplosion.minDelay", 0.0));
+		projectile.setClusterExplosionsMaxDelay(projectileConfig.getDouble("clusterExplosion.maxDelay", 5.0));
+		projectile.setClusterExplosionsRadius(projectileConfig.getDouble("clusterExplosion.radius", 5.0));
+		projectile.setClusterExplosionsPower(projectileConfig.getDouble("clusterExplosion.power", 5.0));
 
 		//spawnOnExplosion
-        projectile.setSpawnEnabled(projectileConfig.getBoolean("spawnOnExplosion.enabled", false));
+		projectile.setSpawnEnabled(projectileConfig.getBoolean("spawnOnExplosion.enabled", false));
 		projectile.setSpawnBlockRadius(projectileConfig.getDouble("spawnOnExplosion.blockRadius", 1.0));
-        projectile.setSpawnEntityRadius(projectileConfig.getDouble("spawnOnExplosion.entityRadius", 2.0));
+		projectile.setSpawnEntityRadius(projectileConfig.getDouble("spawnOnExplosion.entityRadius", 2.0));
 		projectile.setSpawnVelocity(projectileConfig.getDouble("spawnOnExplosion.velocity", 0.1));
 		projectile.setSpawnBlocks(CannonsUtil.toSpawnMaterialHolderList(projectileConfig.getStringList("spawnOnExplosion.block")));
-        projectile.setSpawnEntities(CannonsUtil.toSpawnEntityHolderList(projectileConfig.getStringList("spawnOnExplosion.entity")));
-        projectile.setSpawnProjectiles(projectileConfig.getStringList("spawnOnExplosion.projectiles"));
+		projectile.setSpawnEntities(CannonsUtil.toSpawnEntityHolderList(projectileConfig.getStringList("spawnOnExplosion.entity")));
+		projectile.setSpawnProjectiles(projectileConfig.getStringList("spawnOnExplosion.projectiles"));
 
-        //spawnFireworks
-        projectile.setFireworksEnabled(projectileConfig.getBoolean("spawnFireworks.enabled", false));
-        projectile.setFireworksFlicker(projectileConfig.getBoolean("spawnFireworks.flicker",false));
-        projectile.setFireworksTrail(projectileConfig.getBoolean("spawnFireworks.trail",false));
-        projectile.setFireworksType(getFireworksType(projectileConfig.getString("spawnFireworks.type", "BALL")));
-        projectile.setFireworksColors(toColor(projectileConfig.getStringList("spawnFireworks.colors")));
-        projectile.setFireworksFadeColors(toColor(projectileConfig.getStringList("spawnFireworks.fadeColors")));
+		//spawnFireworks
+		projectile.setFireworksEnabled(projectileConfig.getBoolean("spawnFireworks.enabled", false));
+		projectile.setFireworksFlicker(projectileConfig.getBoolean("spawnFireworks.flicker",false));
+		projectile.setFireworksTrail(projectileConfig.getBoolean("spawnFireworks.trail",false));
+		projectile.setFireworksType(getFireworksType(projectileConfig.getString("spawnFireworks.type", "BALL")));
+		projectile.setFireworksColors(toColor(projectileConfig.getStringList("spawnFireworks.colors")));
+		projectile.setFireworksFadeColors(toColor(projectileConfig.getStringList("spawnFireworks.fadeColors")));
 
-        //messages
-        projectile.setImpactMessage(projectileConfig.getBoolean("messages.hasImpactMessage", false));
+		//messages
+		projectile.setImpactMessage(projectileConfig.getBoolean("messages.hasImpactMessage", false));
 
-        //sounds
-        projectile.setSoundLoading(new SoundHolder(projectileConfig.getString("sounds.loading", "BLOCK_STONE_PLACE:5:0.5")));
-        projectile.setSoundImpact(new SoundHolder(projectileConfig.getString("sounds.impact", "ENTITY_GENERIC_EXPLODE:10:0.5")));
-        projectile.setSoundImpactProtected(new SoundHolder(projectileConfig.getString("sounds.impactProtected", "ENTITY_GENERIC_EXPLODE:10:0.5")));
-        projectile.setSoundImpactWater(new SoundHolder(projectileConfig.getString("sounds.impactWater", "ENTITY_GENERIC_SPLASH:10:0.3")));
+		//sounds
+		projectile.setSoundLoading(new SoundHolder(projectileConfig.getString("sounds.loading", "BLOCK_STONE_PLACE:5:0.5")));
+		projectile.setSoundImpact(new SoundHolder(projectileConfig.getString("sounds.impact", "ENTITY_GENERIC_EXPLODE:10:0.5")));
+		projectile.setSoundImpactProtected(new SoundHolder(projectileConfig.getString("sounds.impactProtected", "ENTITY_GENERIC_EXPLODE:10:0.5")));
+		projectile.setSoundImpactWater(new SoundHolder(projectileConfig.getString("sounds.impactWater", "ENTITY_GENERIC_SPLASH:10:0.3")));
 
 		//loadPermissions
 		projectile.setPermissionLoad(projectileConfig.getStringList("loadPermission"));
-		
+
 		return projectile;
 	}
-	
-	
+
+
 	/**
 	 * copys the default designs from the .jar to the disk
 	 */
 	private void copyDefaultProjectiles()
-    {
-        copyFile("canistershot");
-        copyFile("tnt");
-        copyFile("cobblestone");
-        copyFile("diamond");
+	{
+		copyFile("canistershot");
+		copyFile("tnt");
+		copyFile("cobblestone");
+		copyFile("diamond");
 
-        copyFile("enderpearl");
+		copyFile("enderpearl");
 
-        copyFile("firework1");
-        copyFile("firework2");
-        copyFile("firework3");
-        copyFile("firework4");
+		copyFile("firework1");
+		copyFile("firework2");
+		copyFile("firework3");
+		copyFile("firework4");
 	}
 
-    /**
-     * copies the yml file from the .jar to the projectile folder
-     * @param filename - name of the .yml file
-     */
-    private void copyFile(String filename)
-    {
-        File YmlFile = new File(plugin.getDataFolder(), "projectiles/" + filename + ".yml");
+	/**
+	 * copies the yml file from the .jar to the projectile folder
+	 * @param filename - name of the .yml file
+	 */
+	private void copyFile(String filename)
+	{
+		File YmlFile = new File(plugin.getDataFolder(), "projectiles/" + filename + ".yml");
 
-        YmlFile.getParentFile().mkdirs();
-        if (!YmlFile.exists())
-        {
-            CannonsUtil.copyFile(plugin.getResource("projectiles/" + filename + ".yml"), YmlFile);
-        }
-    }
-	
-	
+		YmlFile.getParentFile().mkdirs();
+		if (!YmlFile.exists())
+		{
+			CannonsUtil.copyFile(plugin.getResource("projectiles/" + filename + ".yml"), YmlFile);
+		}
+	}
+
+
 	/**
 	 * returns the path of the projectiles folder
 	 * @return
@@ -318,7 +326,7 @@ public class ProjectileStorage
 		// Directory path here
 		return "plugins/Cannons/projectiles/";
 	}
-	
+
 
 	/**
 	 * returns a PotionEffectTypeList from a list of strings
@@ -328,18 +336,18 @@ public class ProjectileStorage
 	private List<PotionEffectType> toPotionEffect(List<String> stringList)
 	{
 		List<PotionEffectType> effectList = new ArrayList<PotionEffectType>();
-		
+
 		for (String str : stringList)
 		{
 			PotionEffectType effect = PotionEffectType.getByName(str);
 			if (effect != null)
 				effectList.add(effect);
-            else
-                plugin.logSevere("No potion effect found with the name: " + str);
+			else
+				plugin.logSevere("No potion effect found with the name: " + str);
 		}
 		return effectList;
 	}
-	
+
 	/**
 	 * returns a PotionEffectTypeList from a list of strings
 	 * @param stringList
@@ -354,87 +362,87 @@ public class ProjectileStorage
 			ProjectileProperties projectile = ProjectileProperties.getByName(str);
 			if (projectile != null)
 				projectileList.add(projectile);
-            else
-                plugin.logSevere("No projectile property with the name: " + str + " found");
+			else
+				plugin.logSevere("No projectile property with the name: " + str + " found");
 		}
 		return projectileList;
 	}
 
 
 
-    /**
-     * returns a list of colors in RGB integer format from a list of strings in hex format
-     * @param stringList
-     * @return
-     */
-    private List<Integer> toColor(List<String> stringList)
-    {
-        List<Integer> colorList = new ArrayList<Integer>();
+	/**
+	 * returns a list of colors in RGB integer format from a list of strings in hex format
+	 * @param stringList
+	 * @return
+	 */
+	private List<Integer> toColor(List<String> stringList)
+	{
+		List<Integer> colorList = new ArrayList<Integer>();
 
-        for (String str : stringList)
-        {
-            try
-            {
-                Integer color = Integer.parseInt(str,16);
-                colorList.add(color);
-            }
-            catch (Exception ex)
-            {
-                plugin.logSevere(str + " is not a hexadecimal number");
-            }
-        }
-        return colorList;
-    }
+		for (String str : stringList)
+		{
+			try
+			{
+				Integer color = Integer.parseInt(str,16);
+				colorList.add(color);
+			}
+			catch (Exception ex)
+			{
+				plugin.logSevere(str + " is not a hexadecimal number");
+			}
+		}
+		return colorList;
+	}
 
-    /**
-     * returns the projectile with the matching ID
-     * @param str
-     * @return
-     */
-    public Projectile getByName(String str)
-    {
-        for (Projectile projectile : projectileList)
-        {
-            if (projectile.getProjectileId().equalsIgnoreCase(str))
-                return projectile;
-        }
-        return null;
-    }
+	/**
+	 * returns the projectile with the matching ID
+	 * @param str
+	 * @return
+	 */
+	public Projectile getByName(String str)
+	{
+		for (Projectile projectile : projectileList)
+		{
+			if (projectile.getProjectileId().equalsIgnoreCase(str))
+				return projectile;
+		}
+		return null;
+	}
 
-    /**
-     * converts a string into a firework effect
-     * @param str - name of the effect
-     * @return fittiong firework effect
-     */
-    FireworkEffect.Type getFireworksType(String str)
-    {
-        try
-        {
-            return FireworkEffect.Type.valueOf(str);
-        }
-        catch(Exception ex)
-        {
-            plugin.logDebug(str + " is not a valid fireworks type. BALL was used instead.");
-            return FireworkEffect.Type.BALL;
-        }
-    }
+	/**
+	 * converts a string into a firework effect
+	 * @param str - name of the effect
+	 * @return fittiong firework effect
+	 */
+	FireworkEffect.Type getFireworksType(String str)
+	{
+		try
+		{
+			return FireworkEffect.Type.valueOf(str);
+		}
+		catch(Exception ex)
+		{
+			plugin.logDebug(str + " is not a valid fireworks type. BALL was used instead.");
+			return FireworkEffect.Type.BALL;
+		}
+	}
 
-    /**
-     * returns converts a string into a firework effect
-     * @param str - name of the effect
-     * @return fittiong firework effect
-     */
-    EntityType getProjectileEntity(String str)
-    {
-        try
-        {
-            return EntityType.valueOf(str.toUpperCase());
-        }
-        catch(Exception ex)
-        {
-            plugin.logSevere(str + " is not a valid entity type. SNOWBALL was used instead.");
-            return EntityType.SNOWBALL;
-        }
-    }
+	/**
+	 * returns converts a string into a firework effect
+	 * @param str - name of the effect
+	 * @return fittiong firework effect
+	 */
+	EntityType getProjectileEntity(String str)
+	{
+		try
+		{
+			return EntityType.valueOf(str.toUpperCase());
+		}
+		catch(Exception ex)
+		{
+			plugin.logSevere(str + " is not a valid entity type. SNOWBALL was used instead.");
+			return EntityType.SNOWBALL;
+		}
+	}
 
 }

--- a/src/main/java/at/pavlov/cannons/scheduler/ProjectileObserver.java
+++ b/src/main/java/at/pavlov/cannons/scheduler/ProjectileObserver.java
@@ -128,7 +128,7 @@ public class ProjectileObserver {
 
             if(distance <= maxDist)
                 plugin.getFakeBlockHandler().imitatedSphere(p, loc, 1, Bukkit.createBlockData(liquid.getType()), FakeBlockType.WATER_SPLASH, 1.0);
-            
+
         }
         CannonsUtil.imitateSound(loc, sound, maxSoundDist, maxVol);
     }
@@ -231,14 +231,18 @@ public class ProjectileObserver {
             cannonball.setLastSmokeTrailLocation(newLoc);
             plugin.logDebug("smoke trail at: " +  newLoc.getBlockX() + "," + newLoc.getBlockY() + "," + newLoc.getBlockZ());
 
-            for(Player p : newLoc.getWorld().getPlayers())
-            {
-                Location pl = p.getLocation();
-                double distance = pl.distance(newLoc);
+            if (proj.isSmokeTrailParticleEnabled()) {
+                cannonball.getWorld().spawnParticle(proj.getSmokeTrailParticleType(), newLoc, proj.getSmokeTrailParticleCount(), proj.getSmokeTrailParticleOffsetX(), proj.getSmokeTrailParticleOffsetY(), proj.getSmokeTrailParticleOffsetZ(), proj.getSmokeTrailParticleSpeed(), null, true);
+            }
+            else {
+                for (Player p : newLoc.getWorld().getPlayers()) {
+                    Location pl = p.getLocation();
+                    double distance = pl.distance(newLoc);
 
-                if(distance <= maxDist)
-                    plugin.getFakeBlockHandler().imitatedSphere(p, newLoc, 0, proj.getSmokeTrailMaterial(), FakeBlockType.SMOKE_TRAIL, smokeDuration);
+                    if (distance <= maxDist)
+                        plugin.getFakeBlockHandler().imitatedSphere(p, newLoc, 0, proj.getSmokeTrailMaterial(), FakeBlockType.SMOKE_TRAIL, smokeDuration);
 
+                }
             }
         }
 

--- a/src/main/resources/projectiles/canistershot.yml
+++ b/src/main/resources/projectiles/canistershot.yml
@@ -51,6 +51,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.

--- a/src/main/resources/projectiles/canistershot.yml
+++ b/src/main/resources/projectiles/canistershot.yml
@@ -53,7 +53,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/cobblestone.yml
+++ b/src/main/resources/projectiles/cobblestone.yml
@@ -54,6 +54,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.

--- a/src/main/resources/projectiles/cobblestone.yml
+++ b/src/main/resources/projectiles/cobblestone.yml
@@ -56,7 +56,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/diamond.yml
+++ b/src/main/resources/projectiles/diamond.yml
@@ -57,7 +57,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/diamond.yml
+++ b/src/main/resources/projectiles/diamond.yml
@@ -55,6 +55,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.

--- a/src/main/resources/projectiles/enderpearl.yml
+++ b/src/main/resources/projectiles/enderpearl.yml
@@ -55,7 +55,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/enderpearl.yml
+++ b/src/main/resources/projectiles/enderpearl.yml
@@ -53,6 +53,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.

--- a/src/main/resources/projectiles/firework1.yml
+++ b/src/main/resources/projectiles/firework1.yml
@@ -25,6 +25,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 cannonball:
   #the type of the projectile entity

--- a/src/main/resources/projectiles/firework1.yml
+++ b/src/main/resources/projectiles/firework1.yml
@@ -27,7 +27,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/firework2.yml
+++ b/src/main/resources/projectiles/firework2.yml
@@ -54,6 +54,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.

--- a/src/main/resources/projectiles/firework2.yml
+++ b/src/main/resources/projectiles/firework2.yml
@@ -56,7 +56,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/firework3.yml
+++ b/src/main/resources/projectiles/firework3.yml
@@ -55,7 +55,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/firework3.yml
+++ b/src/main/resources/projectiles/firework3.yml
@@ -53,6 +53,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.

--- a/src/main/resources/projectiles/firework4.yml
+++ b/src/main/resources/projectiles/firework4.yml
@@ -55,7 +55,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/firework4.yml
+++ b/src/main/resources/projectiles/firework4.yml
@@ -53,6 +53,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.

--- a/src/main/resources/projectiles/tnt.yml
+++ b/src/main/resources/projectiles/tnt.yml
@@ -55,7 +55,7 @@ smokeTrail:
   duration: 5.0
   particles:
     # whether to use particles for the smoke trail instead of a block
-    enabled: true
+    enabled: false
     # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
     type: SMOKE_NORMAL
     # how many particles to spawn

--- a/src/main/resources/projectiles/tnt.yml
+++ b/src/main/resources/projectiles/tnt.yml
@@ -53,6 +53,19 @@ smokeTrail:
   material: 'minecraft:cobweb'
   #how long the smoke will stay in seconds
   duration: 5.0
+  particles:
+    # whether to use particles for the smoke trail instead of a block
+    enabled: true
+    # name of the particle to use - see https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for a list
+    type: SMOKE_NORMAL
+    # how many particles to spawn
+    count: 1
+    # the x, y and z offset of the particles
+    x_offset: 0
+    y_offset: 0
+    z_offset: 0
+    # how fast the particle travels to its offset position
+    speed: 1
 
 explosion:
   #the explosion power of the cannonball when it hits; this number determines the explosions range in blocks.


### PR DESCRIPTION
# Description

This PR adds an option to use particles instead of blocks for a projectile's smoke trail. 

I have very briefly tested this on my 1.16.5 server and have found no issues. Apologies for the accidental large diff in one of the commits.

## Examples

Using the `FLASH` particle effect to create a flare: 

![Flare](https://i.gyazo.com/0368f24f38b5c891ce0997177ede297f.png)

Using the `CAMPFIRE_SIGNAL_SMOKE` particle effect to create a smoke trail: 

![Smoke Trail](https://i.gyazo.com/a7149f73f5bc10fd371795ae43b1522e.png)

