### PR TITLE
Added entity to entity explode event

### DIFF
--- a/src/main/java/at/pavlov/cannons/CreateExplosion.java
+++ b/src/main/java/at/pavlov/cannons/CreateExplosion.java
@@ -203,7 +203,7 @@ public class CreateExplosion {
 				this.plugin.getServer().getPluginManager().callEvent(piercingEvent);
 
 				// create bukkit event
-				EntityExplodeEvent event = new EntityExplodeEvent(null, impactLoc, piercingEvent.getBlockList(), 1.0f);
+				EntityExplodeEvent event = new EntityExplodeEvent(projectile_entity, impactLoc, piercingEvent.getBlockList(), 1.0f);
 				this.plugin.getServer().getPluginManager().callEvent(event);
 
 				this.plugin.logDebug("was the cannons explode event canceled: " + event.isCancelled());


### PR DESCRIPTION
**Description**
- Hi, I'm a developer of SiegeWar, for TownyAdvanced
- I'm currently trying to develop a neat integration between SiegeWar and your plugin
- I've nearly completed the integration, however, there is an issue I need to resolve first:
  - Currently, cannonballs break Towny's town protections
  - This is because an EntityExplodeEvent triggered by Cannons does not supply an entity
  - This results in a null pointer exception over on Towny, and the cannonball gets through

**Fix**
- In this PR I fix the issue by supplying the triggered event with an entity
- I tested this on my local server and it fixes the issue, Towny's protections hold with no NPE