### PR TITLE
Add BreakCause to CannonDestroyedEvent

### DIFF
--- a/src/main/java/at/pavlov/cannons/cannon/CannonManager.java
+++ b/src/main/java/at/pavlov/cannons/cannon/CannonManager.java
@@ -183,7 +183,7 @@ public class CannonManager
 
 
                 //fire and an event that this cannon is destroyed
-                CannonDestroyedEvent destroyedEvent = new CannonDestroyedEvent(cannon);
+                CannonDestroyedEvent destroyedEvent = new CannonDestroyedEvent(cannon, cause);
                 Bukkit.getServer().getPluginManager().callEvent(destroyedEvent);
 
                 if (cannon.getOwner() != null) {

--- a/src/main/java/at/pavlov/cannons/event/CannonDestroyedEvent.java
+++ b/src/main/java/at/pavlov/cannons/event/CannonDestroyedEvent.java
@@ -1,5 +1,6 @@
 package at.pavlov.cannons.event;
 
+import at.pavlov.cannons.Enum.BreakCause;
 import at.pavlov.cannons.cannon.Cannon;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -7,10 +8,11 @@ import org.bukkit.event.HandlerList;
 public class CannonDestroyedEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 	private final Cannon cannon;
+    private final BreakCause breakCause;
 
-	public CannonDestroyedEvent(Cannon cannon) {
-
+	public CannonDestroyedEvent(Cannon cannon, BreakCause breakCause) {
         this.cannon = cannon;
+        this.breakCause = breakCause;
     }
 	
 	public HandlerList getHandlers() {
@@ -23,5 +25,9 @@ public class CannonDestroyedEvent extends Event {
 
     public Cannon getCannon() {
         return cannon;
+    }
+
+    public BreakCause getBreakCause() {
+        return breakCause;
     }
 }


### PR DESCRIPTION
This PR allows developers to get the `BreakCause` of a cannon's destruction from the `CannonDestroyedEvent`. Knowing the exact reason why a cannon was destroyed is useful for multiple reasons, e.g. one may want to create magazine explosions when a cannon is blown up, but not dismantled. 