### PR TITLE
Fix StackOverflowError on direct entity impacts

### DIFF
--- a/src/main/java/at/pavlov/cannons/projectile/FlyingProjectile.java
+++ b/src/main/java/at/pavlov/cannons/projectile/FlyingProjectile.java
@@ -37,7 +37,7 @@ public class FlyingProjectile
     private boolean teleported;
     //was the projectile fired by a player, redstone or a sentry
     private ProjectileCause projectileCause;
-
+    private boolean hasDetonated;
     private MovingObject predictor;
 
 
@@ -316,5 +316,13 @@ public class FlyingProjectile
 
     public void setImpactBlock(Location impactBlock) {
         this.impactBlock = impactBlock;
+    }
+
+    public boolean hasDetonated() {
+        return this.hasDetonated;
+    }
+
+    public void setHasDetonated(boolean detonated) {
+        this.hasDetonated = detonated;
     }
 }

--- a/src/main/java/at/pavlov/cannons/projectile/ProjectileManager.java
+++ b/src/main/java/at/pavlov/cannons/projectile/ProjectileManager.java
@@ -136,7 +136,8 @@ public class ProjectileManager
         if (fproj != null)
         {
             org.bukkit.entity.Projectile projectile_entity = fproj.getProjectileEntity();
-            if (cannonball.isValid()) {
+            if (!fproj.hasDetonated() && cannonball.isValid()) {
+                fproj.setHasDetonated(true);
                 plugin.getExplosion().directHit(fproj, projectile_entity, target);
                 projectile_entity.remove();
             }


### PR DESCRIPTION
The `EntityDamageByEntityEvent` listener in `EntityListener` class triggers whenever a projectile damages an entity. It then runs the direct hit logic, which will detonate the projectile if it belongs to Cannons. The problem is that detonating the projectile will damage the entity again, which will be picked up by the `EntityDamageByEntityEvent` which will detonate the projectile again, and so on. This recursion triggers a `StackOverflowError` as described in TylerS1066/Movecraft-Cannons#15. This PR adds a `hasDetonated` field to `FlyingProjectile` so that we only detonate the projectile if it hasn't detonated already.